### PR TITLE
Change querykeys to allow for single key selection

### DIFF
--- a/src/tools.js
+++ b/src/tools.js
@@ -10,10 +10,10 @@ function querykeys(path, starttime, endtime){
 	var start = path;
 	var end = path;
 	if(starttime){
-		start = '.' + starttime;
+		start += '.' + starttime;
 	}
 	if(endtime){
-		end = '.' + endtime;
+		end += '.' + endtime;
 	}
 	return levelrange(start, end);
 }


### PR DESCRIPTION
I have a need to update the metadata on an already specified index. I hit a snag with the way the path was being constructed because it was adding the period to the path upfront meaning I could never get back to the original path.

The  changes below only add the period if a start or end time is specified.
