### PR TITLE
Load the latest version of level

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/binocarlos/lem",
   "dependencies": {
     "through": "~2.3.4",
-    "level": "~0.18.0",
+    "level": "~1.4.0",
     "level-live-stream": "~1.4.9"
   }
 }


### PR DESCRIPTION
This helps prevent build errors in Node 6 (I haven't tested in other environments):

```
In file included from ../src/batch.cc:5:
../../../../nan/nan.h:602:20: error: no type named 'GCEpilogueCallback' in 'v8::Isolate'
      v8::Isolate::GCEpilogueCallback callback
      ~~~~~~~~~~~~~^
../../../../nan/nan.h:608:20: error: no type named 'GCEpilogueCallback' in 'v8::Isolate'
      v8::Isolate::GCEpilogueCallback callback) {
      ~~~~~~~~~~~~~^
../../../../nan/nan.h:613:20: error: no type named 'GCPrologueCallback' in 'v8::Isolate'
      v8::Isolate::GCPrologueCallback callback
      ~~~~~~~~~~~~~^
../../../../nan/nan.h:619:20: error: no type named 'GCPrologueCallback' in 'v8::Isolate'
      v8::Isolate::GCPrologueCallback callback) {
      ~~~~~~~~~~~~~^
4 errors generated.
make: *** [Release/obj.target/leveldown/src/batch.o] Error 1
```

### Workaround

The only other workaround I've found is to force this dependency to update in shrinkwrap but `npm install name-of-any-dependency -D` keeps failing which is quite the friction:


```js
// npm-shrinkwrap.json
{
  "dependencies": {
    "lem": {
      "version": "0.4.8",
      "from": "lem@0.4.8",
      "dependencies": {
        "level": {
          "version": "1.4.0",
          "level": "~0.18.0"
        }
      }
    }
  }
}
```